### PR TITLE
Clarify security on health check operation

### DIFF
--- a/src/main/openapi/common/v1/common-v1.yaml
+++ b/src/main/openapi/common/v1/common-v1.yaml
@@ -7,7 +7,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers: []
 paths:
-  /health:
+  /health: # copy this path instead of referencing it to modify security section. Operation may be secured, but access should be allowed to all clients.
     get:
       tags:
         - Monitoring

--- a/src/main/openapi/common/v1/common-v1.yaml
+++ b/src/main/openapi/common/v1/common-v1.yaml
@@ -7,7 +7,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers: []
 paths:
-  /health: # copy this path instead of referencing it to modify security section. Operation may be secured, but access should be allowed to all clients.
+  /health: # Operation may be secured, but access should be allowed to all clients. In order to add a security scheme, copy this definition instead of referencing it.
     get:
       tags:
         - Monitoring

--- a/src/main/swagger/common/v1/common-v1.yaml
+++ b/src/main/swagger/common/v1/common-v1.yaml
@@ -6,7 +6,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 paths:
-  /health:
+  /health:  # Operation may be secured, but access should be allowed to all clients. In order to add a security scheme, copy this definition instead of referencing it.
     get:
       tags:
         - Monitoring


### PR DESCRIPTION
Add comment to copy the "/health" entry instead of referencing it to modify security section. 
The "/health" operation forces to have no security, but this often not wanted.

I'd rather move it to the belgif guide as an example rather than including it in openapi-common, but that could break backwards-compatibility.