### PR TITLE
Deprecate MergePatch and add `additionalProperties: true`

### DIFF
--- a/src/main/openapi/common/v1/common-v1.yaml
+++ b/src/main/openapi/common/v1/common-v1.yaml
@@ -142,9 +142,10 @@ components:
         de:
           type: string
     MergePatch:
+      deprecated: true # Define a specific schema for JSON Merge patch request body instead of using this marker type (see [doc-patch] rule)
       description: JSON Merge Patch (RFC 7386) request body
       type: object
-      # Marker type as JSON Merge Patch requests can not be fully specified as a JSON Schema type
+      additionalProperties: true
     SelfLink:
       description: A base type representing a link to the resource's own location within its representation
       type: object

--- a/src/main/swagger/common/v1/common-v1.yaml
+++ b/src/main/swagger/common/v1/common-v1.yaml
@@ -128,6 +128,7 @@ definitions:
   MergePatch:
     description: JSON Merge Patch (RFC 7386) request body
     type: object
+    additionalProperties: true
     # Marker type as JSON Merge Patch requests can not be fully specified as a JSON Schema type
   SelfLink:
     description: A base type representing a link to the resource's own location within its representation


### PR DESCRIPTION
- Deprecate MergePatch in OpenAPI 3.0
- Add explicit `additionalProperties: true` to MergePatch for better code generation

https://github.com/belgif/rest-guide/issues/189