### PR TITLE
Add PhoneNumber schema

### DIFF
--- a/src/main/openapi/common/v1/common-v1.yaml
+++ b/src/main/openapi/common/v1/common-v1.yaml
@@ -149,6 +149,11 @@ components:
       description: JSON Merge Patch (RFC 7386) request body
       type: object
       additionalProperties: true
+    PhoneNumber:
+      type: string
+      description: A phone number based on the E.164 format, starting with a `+` prefix, and followed by the country code (1 to 3 digits) and subscriber number (includes area code and local number)
+      pattern: '^\+[1-9]\d{6,14}$' # minimal length of 7 digits after the `+` with first digit not a 0
+      # For end-user input, it is recommended to accept a more characters (e.g. spaces, slashes, ...) before transforming to this format
     SelfLink:
       description: A base type representing a link to the resource's own location within its representation
       type: object

--- a/src/main/openapi/common/v1/common-v1.yaml
+++ b/src/main/openapi/common/v1/common-v1.yaml
@@ -153,7 +153,7 @@ components:
       type: string
       description: A phone number based on the E.164 format, starting with a `+` prefix, and followed by the country code (1 to 3 digits) and subscriber number (includes area code and local number)
       pattern: '^\+[1-9]\d{6,14}$' # minimal length of 7 digits after the `+` with first digit not a 0
-      # For end-user input, it is recommended to accept a more characters (e.g. spaces, slashes, ...) before transforming to this format
+      # For end-user input, it is recommended to be more accepting (e.g. spaces, slashes, ...) and automatically normalize to this format
     SelfLink:
       description: A base type representing a link to the resource's own location within its representation
       type: object


### PR DESCRIPTION
Based on https://github.com/belgif/fedvoc/issues/57

Remarks:
* to validate with fedvoc wg:
  * name 'PhoneNumber' and description of the schema - FedVoc defines a 'telephone' property but not explicit data type
    * as property name `telephone` can still be understood, but for a data type it's weirder. Modern web forms also seem to use more "phone number" or "phone", while "telephone" more in formal or legal communication.
  * pattern was changed to enforce minimum of 7 digits instead of 2 (7 is a safe practical commonly used minimum from what I can find)
* This data type is a normalized representation,  it is recommended to be more accepting (e.g. spaces, slashes, ...) and automatically normalize to this format